### PR TITLE
Karma 0.13.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,7 @@ var karmaSettings = {
     files: [
         './tests/*.spec.js'
     ],
-    junitReporter: {
-        outputFile: './fe-test-results.xml'
-    },
-    reporters: ['progress', 'junit'],
+    reporters: ['progress'],
     port: 9876,
     colors: true,
     autoWatch: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rehab-fe-skeleton-testsuite",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "A wrapper for the test suite of the rehabstudio front-end skeleton.",
     "homepage": "https://github.com/rehabstudio/fe-skeleton-testsuite",
     "main": "src/index.js",
@@ -21,17 +21,16 @@
         "test": "node tests/test.js"
     },
     "dependencies": {
-        "chai": "^2.3.0",
+        "chai": "^3.2.0",
         "mocha": "^2.2.5",
-        "sinon": "^1.14.1",
-        "karma": "^0.12.31",
+        "sinon": "^1.15.4",
+        "karma": "^0.13.4",
         "karma-chai": "^0.1.0",
-        "karma-mocha": "^0.1.10",
+        "karma-mocha": "^0.2.0",
         "karma-sinon": "^1.0.4",
-        "karma-phantomjs-launcher": "^0.1.4",
-        "karma-junit-reporter": "^0.2.2",
-        "karma-browserify": "^4.1.2",
+        "karma-phantomjs-launcher": "^0.2.0",
+        "karma-browserify": "^4.2.1",
         "browserify-istanbul": "^0.2.1",
-        "karma-coverage": "^0.3.1"
+        "karma-coverage": "^0.4.2"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -12,12 +12,14 @@ module.exports = {
      *  @param {function} resolveFn - Gulp async function.
      */
     runTests: function(karmaSettings, resolveFn) {
-        karma.server.start(karmaSettings, function(exitCode) {
+        var testServer = new karma.Server(karmaSettings, function(exitCode) {
             if (typeof(resolveFn) === 'function') {
                 resolveFn(exitCode);
             } else {
                 process.exit(exitCode);
             }
         });
+
+        testServer.start();
     }
 };

--- a/tests/test.js
+++ b/tests/test.js
@@ -15,10 +15,7 @@ var karmaSettings = {
     files: [
         './tests/*.spec.js'
     ],
-    junitReporter: {
-        outputFile: './fe-test-results.xml'
-    },
-    reporters: ['progress', 'junit'],
+    reporters: ['progress'],
     port: 9876,
     colors: true,
     autoWatch: false,
@@ -27,6 +24,7 @@ var karmaSettings = {
 };
 
 // Test call to the test suite wrapper.
-testSuiteWrapper.runTests(karmaSettings, function() {
-	console.log('Callback called.');
+testSuiteWrapper.runTests(karmaSettings, function(exitCode) {
+    console.log('Callback called.');
+    console.log('Karma Exit Code:', exitCode);
 });


### PR DESCRIPTION
- Bumped all dependencies.
- Updated test suite code to use new syntax of Karma 0.13.x.
- Test script now outputs the exit code it received from the runTests method.
- Removed JUnit reporter as it's not compatible with newest versions of Karma, plus it's not used now that CircleCI is taking the place of Jenkins.