### PR TITLE
Reporters: JUnit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ build/Release
 node_modules
 .lock-wscript
 docs/_build/doctrees/environment.pickle
-fe-test-results.xml
+test-results/
 fe-coverage-results.xml

--- a/README.md
+++ b/README.md
@@ -47,8 +47,15 @@ var karmaSettings = {
     },
 
     reporters: [
-        'progress'
+        'progress',
+        'junit'
     ],
+
+    junitReporter: {
+        outputDir: './test-results',
+        outputFile: 'results.xml',
+        useBrowserName: false
+    },
 
     browsers: [
         'PhantomJS'
@@ -106,8 +113,15 @@ var karmaSettings = {
     },
 
     reporters: [
-        'progress'
+        'progress',
+        'junit'
     ],
+
+    junitReporter: {
+        outputDir: './test-results',
+        outputFile: 'results.xml',
+        useBrowserName: false
+    },
 
     browsers: [
         'PhantomJS'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "karma": "0.13.19",
     "karma-chai": "0.1.0",
     "karma-mocha": "0.2.1",
+    "karma-junit-reporter": "1.0.0",
     "karma-phantomjs-launcher": "1.0.0",
     "karma-sinon": "1.0.4",
     "karma-webpack": "1.7.0",

--- a/tests/index.js
+++ b/tests/index.js
@@ -26,7 +26,7 @@ var karmaSettings = {
     },
 
     reporters: [
-        'progress',
+        'progress'
     ],
 
     browsers: [

--- a/tests/index.js
+++ b/tests/index.js
@@ -27,14 +27,7 @@ var karmaSettings = {
 
     reporters: [
         'progress',
-        'junit'
     ],
-
-    junitReporter: {
-        outputDir: './test-results',
-        outputFile: 'results.xml',
-        useBrowserName: false
-    },
 
     browsers: [
         'PhantomJS'

--- a/tests/index.js
+++ b/tests/index.js
@@ -26,8 +26,15 @@ var karmaSettings = {
     },
 
     reporters: [
-        'progress'
+        'progress',
+        'junit'
     ],
+
+    junitReporter: {
+        outputDir: './test-results',
+        outputFile: 'results.xml',
+        useBrowserName: false
+    },
 
     browsers: [
         'PhantomJS'


### PR DESCRIPTION
With our Jenkins cluster now up and running, we can give more detailed test information about what passed and what failed during the most recent running of the suite. This PR sees us re-include the JUnit reporter plugin.